### PR TITLE
Application entity

### DIFF
--- a/example/hello/glue/android/cpp/osal_jni.cpp
+++ b/example/hello/glue/android/cpp/osal_jni.cpp
@@ -12,7 +12,7 @@ using namespace app;
 
 struct OSAL_INSTANCE {
     std::mutex mutex;
-    AppKernel* kernel;
+    Kernel*    kernel;
     jobject    rootview;
     jobject    asset_manager;
 };
@@ -24,7 +24,7 @@ Java_com_shadowpaw_osal_glue_OSALView_jniInit(JNIEnv *env, jobject self, jobject
     data->asset_manager = env->NewGlobalRef(assmgr);
     PlatformSpecificData psd;
     psd.rootview = data->rootview;
-    data->kernel = new AppKernel();
+    data->kernel = new Kernel();
     data->kernel->init(psd);
     data->kernel->vfs()->mount("/assets/", new storage::AssetDriver(data->asset_manager));
     return env->NewDirectByteBuffer((void*)data, sizeof(OSAL_INSTANCE));
@@ -45,6 +45,7 @@ Java_com_shadowpaw_osal_glue_OSALView_jniStartup(JNIEnv *env, jobject self, jobj
     OSAL_INSTANCE* data = (OSAL_INSTANCE*)env->GetDirectBufferAddress(handle);
     std::lock_guard<std::mutex> lock(data->mutex);
     data->kernel->startup();
+    data->kernel->run(new MyApp());
 }
 extern "C" JNIEXPORT void JNICALL
 Java_com_shadowpaw_osal_glue_OSALView_jniShutdown(JNIEnv *env, jobject self, jobject handle) {

--- a/example/hello/glue/ios/AppDelegate.mm
+++ b/example/hello/glue/ios/AppDelegate.mm
@@ -4,7 +4,7 @@
 
 // ----------------------------------------------------------------------------
 @interface AppDelegate()
-@property (nonatomic) app::AppKernel* m_kernel;
+@property (nonatomic) osal::Kernel* m_kernel;
 @end
 
 @implementation AppDelegate
@@ -19,12 +19,13 @@
     OSALView* view = (OSALView*)self.window.rootViewController.view;
     osal::PlatformSpecificData psd;
     psd.rootview = (__bridge void*)view;
-    self.m_kernel = new app::AppKernel();
+    self.m_kernel = new osal::Kernel();
     if (!self.m_kernel->init(psd)) return NO;
     [view setKernel:self.m_kernel];
     self.m_kernel->vfs()->mount("/assets/", new osal::storage::FileDriver([[[NSBundle mainBundle] resourcePath] UTF8String]));
     self.m_kernel->context_restored();
     self.m_kernel->startup();
+    self.m_kernel->run(new Myapp());
 	[view startAnimation];
     return YES;
 }

--- a/example/hello/glue/mac/AppDelegate.mm
+++ b/example/hello/glue/mac/AppDelegate.mm
@@ -4,7 +4,7 @@
 
 // ----------------------------------------------------------------------------
 @interface AppDelegate()
-@property (nonatomic) app::AppKernel* m_kernel;
+@property (nonatomic) osal::Kernel* m_kernel;
 @end
 
 @implementation AppDelegate
@@ -19,7 +19,7 @@
 
     osal::PlatformSpecificData psd;
     psd.rootview = (__bridge void*)view;
-    self.m_kernel = new app::AppKernel();
+    self.m_kernel = new osal::Kernel();
     if (!self.m_kernel->init(psd)) {
         exit(0);
         return;
@@ -28,6 +28,7 @@
     self.m_kernel->vfs()->mount("/assets/", new osal::storage::FileDriver([[[NSBundle mainBundle] resourcePath] UTF8String]));
     self.m_kernel->context_restored();
     self.m_kernel->startup();
+    self.m_kernel->run(new MyApp());
     [view startAnimation];
 }
 - (void)applicationWillTerminate:(NSNotification *)aNotification {

--- a/example/hello/glue/win/osalview.cpp
+++ b/example/hello/glue/win/osalview.cpp
@@ -64,7 +64,7 @@ bool OSALView::init(const char* title, int width, int height) {
     GetClientRect(m_hwnd, &rc);
     int win_w = width + width - (rc.right - rc.left);
     int win_h = height + height - (rc.bottom - rc.top);
-    SetWindowPos(m_hwnd, NULL, 0, 0, win_w, win_h, SWP_NOCOPYBITS | SWP_NOMOVE | SWP_NOREDRAW | SWP_NOZORDER | SWP_SHOWWINDOW);
+    SetWindowPos(m_hwnd, NULL, 0, 0, win_w, win_h, SWP_NOCOPYBITS | SWP_NOMOVE | SWP_NOZORDER | SWP_SHOWWINDOW);
     // size
     glViewport(0, 0, width, height);
     m_width = width;

--- a/example/hello/glue/win/winmain.cpp
+++ b/example/hello/glue/win/winmain.cpp
@@ -14,7 +14,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR pCmdLine, int nCmdShow)
 
     PlatformSpecificData psd;
     psd.rootview = view->hwnd();
-    AppKernel* kernel = new AppKernel();
+    osal::Kernel* kernel = new osal::Kernel();
 	if ( !kernel->init(psd) ) return 0;
     view->set_kernel(kernel);
     // mount our assets
@@ -22,6 +22,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR pCmdLine, int nCmdShow)
     kernel->context_restored();
     kernel->resize(view->width(), view->height());
     kernel->startup();
+    kernel->run(new MyApp());
     MSG msg = { 0 };
     BOOL bRet;
     while ((bRet = GetMessage(&msg, NULL, 0, 0)) != 0) {

--- a/example/hello/src/app.cpp
+++ b/example/hello/src/app.cpp
@@ -4,15 +4,15 @@ using namespace app;
 using namespace osal;
 
 // ----------------------------------------------------------------------------
-AppKernel::AppKernel() {
+MyApp::MyApp() {
 }
 // ----------------------------------------------------------------------------
-AppKernel::~AppKernel() {
+MyApp::~MyApp() {
 }
 // ----------------------------------------------------------------------------
-bool AppKernel::cb_startup(Timestamp now) {
+bool MyApp::cb_startup(Timestamp now) {
     storage::Buffer buf;
-    if (vfs()->read("/assets/test.txt", buf)) {
+    if (kernel()->vfs()->read("/assets/test.txt", buf)) {
         util::Logger::d("app", (const char*)buf.data());
     }
     std::unordered_map<int, std::string> uniforms = {
@@ -25,26 +25,32 @@ bool AppKernel::cb_startup(Timestamp now) {
         { 2, "inColor"    },
         { 3, "inTexcoord" }
     };
-    const gfx::Shader* shader = res()->retain_shader("/assets/shader/test", uniforms, attrs);
+    const gfx::Shader* shader = kernel()->res()->retain_shader("/assets/shader/test", uniforms, attrs);
     util::Logger::d("app", "shader: %p", shader);
-    res()->release_shader(shader);
+    kernel()->res()->release_shader(shader);
     return true;
 }
 // ----------------------------------------------------------------------------
-void AppKernel::cb_shutdown(Timestamp now) {
+void MyApp::cb_shutdown(Timestamp now) {
 }
 // ----------------------------------------------------------------------------
-bool AppKernel::cb_context_lost() {
+void MyApp::cb_pause() {
+}
+// ----------------------------------------------------------------------------
+void MyApp::cb_resume() {
+}
+// ----------------------------------------------------------------------------
+bool MyApp::cb_context_lost() {
     return true;
 }
 // ----------------------------------------------------------------------------
-void AppKernel::cb_context_restored() {
+void MyApp::cb_context_restored() {
 }
 // ----------------------------------------------------------------------------
-void AppKernel::cb_resize(int width, int height) {
+void MyApp::cb_resize(int width, int height) {
 }
 // ----------------------------------------------------------------------------
-void AppKernel::cb_render(gfx::Renderer* r, Timestamp now) {
+void MyApp::cb_render(gfx::Renderer* r, Timestamp now) {
     gfx::Rect2i rect;
     gfx::TextStyle style;
     rect.set(10, 10, 100, 40);

--- a/example/hello/src/app.h
+++ b/example/hello/src/app.h
@@ -5,14 +5,15 @@
 
 namespace app {
 // ----------------------------------------------------------------------------
-class AppKernel : public osal::Kernel {
+class MyApp : public osal::Application {
 public:
-    AppKernel();
-    virtual ~AppKernel();
-
+    MyApp();
+    virtual ~MyApp();
 protected:
     virtual bool cb_startup(osal::Timestamp now);
     virtual void cb_shutdown(osal::Timestamp now);
+    virtual void cb_pause();
+    virtual void cb_resume();
     virtual bool cb_context_lost();
     virtual void cb_context_restored();
     virtual void cb_resize(int width, int height);

--- a/libosal/include/libosal.h
+++ b/libosal/include/libosal.h
@@ -4,6 +4,7 @@
 #include "osal_platform.h"
 #include "osal_type.h"
 #include "osal_kernel.h"
+#include "osal_application.h"
 #include "osal_util_log.h"
 #include "osal_gfx_type.h"
 #include "osal_gfx_renderer.h"

--- a/libosal/include/osal_application.h
+++ b/libosal/include/osal_application.h
@@ -1,0 +1,35 @@
+#ifndef __OSAL_APPLICATION_H__
+#define __OSAL_APPLICATION_H__
+
+#include "osal_platform.h"
+#include "osal_type.h"
+#include "osal_storage_vfs.h"
+#include "osal_gfx_renderer.h"
+#include "osal_gfx_resmgr.h"
+#include "osal_kernel_api.h"
+
+namespace osal {
+// ----------------------------------------------------------------------------
+class Application {
+friend class Kernel;
+public:
+    Application() { m_kernelapi = nullptr; }
+    virtual ~Application() = default;
+protected:
+    virtual bool cb_startup(Timestamp now) = 0;
+    virtual void cb_shutdown(Timestamp now) = 0;
+    virtual void cb_pause() = 0;
+    virtual void cb_resume() = 0;
+    virtual bool cb_context_lost() = 0;
+    virtual void cb_context_restored() = 0;
+    virtual void cb_resize(int width, int height) = 0;
+    virtual void cb_render(gfx::Renderer* r, Timestamp now) = 0;
+protected:
+    KernelAPI* kernel() const { return m_kernelapi; }
+private:
+    KernelAPI* m_kernelapi;
+};
+// ----------------------------------------------------------------------------
+} // namespace osal
+
+#endif // __OSAL_APPLICATION_H__

--- a/libosal/include/osal_gfx_renderer.h
+++ b/libosal/include/osal_gfx_renderer.h
@@ -24,6 +24,7 @@ public:
     int height() const { return m_height; }
     bool is_dirty() const { return m_dirty; }
     void dirty() { m_dirty = true; }
+    bool ready() const { return m_contextready; }
 
 private:
     bool initGL();

--- a/libosal/include/osal_kernel.h
+++ b/libosal/include/osal_kernel.h
@@ -1,44 +1,31 @@
 #ifndef __OSAL_KERNEL_H__
 #define __OSAL_KERNEL_H__
 
+#include <memory>
+#include <list>
 #include "osal_platform.h"
 #include "osal_type.h"
 #include "osal_storage_vfs.h"
 #include "osal_gfx_renderer.h"
 #include "osal_gfx_resmgr.h"
+#include "osal_kernel_api.h"
+#include "osal_application.h"
 
 namespace osal {
 // ----------------------------------------------------------------------------
-class Kernel {
+class Kernel : public KernelAPI {
 public:
     Kernel();
     virtual ~Kernel();
 
     bool init(const PlatformSpecificData& psd);
     void fini();
-
-    Platform platform() const {
-#if defined(PLATFORM_WIN32) || defined(PLATFORM_WIN64)
-        return Platform::Windows;
-#elif defined(PLATFORM_MAC)
-        return Platform::Mac;
-#elif defined(PLATFORM_IOS)
-        return Platform::IOS;
-#elif defined(PLATFORM_ANDROID)
-        return Platform::Android;
-#else
-  #error Not Implemented!
-#endif
-    }
     Timestamp now() const;
 
-public:
-    const PlatformSpecificData* psd() { return &m_psd; }
-    storage::VFS*               vfs() { return &m_vfs; }
-    gfx::Renderer*              renderer() { return &m_renderer; }
-    gfx::ResourceManager*       res() { return &m_res; }
+    bool run(Application* app);
 
 public:
+    // Called from glue
     void startup();
     void shutdown();
     void context_lost();
@@ -50,20 +37,19 @@ public:
     bool timer();
     void render();
 
-protected:
-    virtual bool cb_startup(Timestamp now) = 0;
-    virtual void cb_shutdown(Timestamp now) = 0;
-    virtual bool cb_context_lost() = 0;
-    virtual void cb_context_restored() = 0;
-    virtual void cb_resize(int width, int height) = 0;
-    virtual void cb_render(gfx::Renderer* r, Timestamp now) = 0;
+public:
+    // Kernel API
+    virtual const PlatformSpecificData* psd() { return &m_psd; }
+    virtual storage::VFS*               vfs() { return &m_vfs; }
+    virtual gfx::Renderer*              renderer() { return &m_renderer; }
+    virtual gfx::ResourceManager*       res() { return &m_res; }
 
 private:
     PlatformSpecificData m_psd;
     storage::VFS         m_vfs;
     gfx::Renderer        m_renderer;
     gfx::ResourceManager m_res;
-    
+    std::list<std::unique_ptr<Application>> m_apps;
 };
 // ----------------------------------------------------------------------------
 } // namespace osal

--- a/libosal/include/osal_kernel_api.h
+++ b/libosal/include/osal_kernel_api.h
@@ -1,0 +1,38 @@
+#ifndef __OSAL_KERNEL_API_H__
+#define __OSAL_KERNEL_API_H__
+
+#include "osal_platform.h"
+#include "osal_type.h"
+#include "osal_storage_vfs.h"
+#include "osal_gfx_renderer.h"
+#include "osal_gfx_resmgr.h"
+
+namespace osal {
+// ----------------------------------------------------------------------------
+class KernelAPI {
+public:
+    Platform platform() const {
+#if defined(PLATFORM_WIN32) || defined(PLATFORM_WIN64)
+        return Platform::Windows;
+#elif defined(PLATFORM_MAC)
+        return Platform::Mac;
+#elif defined(PLATFORM_IOS)
+        return Platform::IOS;
+#elif defined(PLATFORM_ANDROID)
+        return Platform::Android;
+#else
+#error Not Implemented!
+#endif
+    }
+
+public:
+    virtual const PlatformSpecificData* psd() = 0;
+    virtual storage::VFS*               vfs() = 0;
+    virtual gfx::Renderer*              renderer() = 0;
+    virtual gfx::ResourceManager*       res() = 0;
+
+};
+// ----------------------------------------------------------------------------
+} // namespace osal
+
+#endif // __OSAL_KERNEL_API_H__

--- a/libosal/proj/libosal.vcxproj
+++ b/libosal/proj/libosal.vcxproj
@@ -36,6 +36,7 @@
     <ClCompile Include="..\src\win\osal_util_log.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\include\osal_application.h" />
     <ClInclude Include="..\include\osal_gfx_draw2d.h" />
     <ClInclude Include="..\include\osal_gfx_drawable.h" />
     <ClInclude Include="..\include\osal_gfx_ibo.h" />
@@ -47,6 +48,7 @@
     <ClInclude Include="..\include\osal_gfx_type.h" />
     <ClInclude Include="..\include\osal_gfx_vbo.h" />
     <ClInclude Include="..\include\osal_kernel.h" />
+    <ClInclude Include="..\include\osal_kernel_api.h" />
     <ClInclude Include="..\include\osal_platform.h" />
     <ClInclude Include="..\include\libosal.h" />
     <ClInclude Include="..\include\osal_storage_buffer.h" />

--- a/libosal/proj/libosal.vcxproj.filters
+++ b/libosal/proj/libosal.vcxproj.filters
@@ -82,6 +82,12 @@
     <ClInclude Include="..\include\win\osal_gfx_canvas.h">
       <Filter>libosal\graphics</Filter>
     </ClInclude>
+    <ClInclude Include="..\include\osal_kernel_api.h">
+      <Filter>libosal\kernel</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\osal_application.h">
+      <Filter>libosal\kernel</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\src\osal_gfx_renderer.cpp">


### PR DESCRIPTION
- User code do not extend `osal::Kernel`, but create `osal::Application`
- `osal::Application` has lifecycle events
- `osal::Application` can access kernel via `KernelAPI`

